### PR TITLE
Add CallNamed() method to make call using named parameters.

### DIFF
--- a/jsonrpc.go
+++ b/jsonrpc.go
@@ -130,10 +130,12 @@ func (client *RPCClient) NewRPCNotificationObject(method string, params ...inter
 //
 // If the request was successful the Error field is nil and the Result field of the RPCRespnse struct contains the rpc result.
 func (client *RPCClient) Call(method string, params ...interface{}) (*RPCResponse, error) {
-	if len(params) == 0 {
-		params = nil
+	// Ensure that params are nil and will be omitted from JSON if not specified.
+	var p interface{}
+	if len(params) != 0 {
+		p = params
 	}
-	httpRequest, err := client.newRequest(false, method, params)
+	httpRequest, err := client.newRequest(false, method, p)
 	if err != nil {
 		return nil, err
 	}
@@ -276,7 +278,6 @@ func (client *RPCClient) SetHTTPClient(httpClient *http.Client) {
 }
 
 func (client *RPCClient) newRequest(notification bool, method string, params interface{}) (*http.Request, error) {
-
 	// TODO: easier way to remove ID from RPCRequest without extra struct
 	var rpcRequest interface{}
 	if notification {

--- a/jsonrpc.go
+++ b/jsonrpc.go
@@ -131,12 +131,35 @@ func (client *RPCClient) NewRPCNotificationObject(method string, params ...inter
 //
 // If the request was successful the Error field is nil and the Result field of the RPCRespnse struct contains the rpc result.
 func (client *RPCClient) Call(method string, params ...interface{}) (*RPCResponse, error) {
-	httpRequest, err := client.newRequest(false, method, params...)
+	if len(params) == 0 {
+		params = nil
+	}
+	httpRequest, err := client.newRequest(false, method, params)
 	if err != nil {
 		return nil, err
 	}
+	return client.doCall(httpRequest)
+}
 
-	httpResponse, err := client.httpClient.Do(httpRequest)
+// CallNamed sends an jsonrpc request over http to the rpc-service url that was provided on client creation.
+// This differs from Call() by sending named, rather than positional, arguments.
+//
+// If something went wrong on the network / http level or if json parsing failed it returns an error.
+//
+// If something went wrong on the rpc-service / protocol level the Error field of the returned RPCResponse is set
+// and contains information about the error.
+//
+// If the request was successful the Error field is nil and the Result field of the RPCRespnse struct contains the rpc result.
+func (client *RPCClient) CallNamed(method string, params map[string]interface{}) (*RPCResponse, error) {
+	httpRequest, err := client.newRequest(false, method, params)
+	if err != nil {
+		return nil, err
+	}
+	return client.doCall(httpRequest)
+}
+
+func (client *RPCClient) doCall(req *http.Request) (*RPCResponse, error) {
+	httpResponse, err := client.httpClient.Do(req)
 	if err != nil {
 		return nil, err
 	}
@@ -156,7 +179,10 @@ func (client *RPCClient) Call(method string, params ...interface{}) (*RPCRespons
 // Notification sends a jsonrpc request to the rpc-service. The difference to Call() is that this request does not expect a response.
 // The ID field of the request is omitted.
 func (client *RPCClient) Notification(method string, params ...interface{}) error {
-	httpRequest, err := client.newRequest(true, method, params...)
+	if len(params) == 0 {
+		params = nil
+	}
+	httpRequest, err := client.newRequest(true, method, params)
 	if err != nil {
 		return err
 	}
@@ -250,7 +276,7 @@ func (client *RPCClient) SetHTTPClient(httpClient *http.Client) {
 	client.httpClient = httpClient
 }
 
-func (client *RPCClient) newRequest(notification bool, method string, params ...interface{}) (*http.Request, error) {
+func (client *RPCClient) newRequest(notification bool, method string, params interface{}) (*http.Request, error) {
 
 	// TODO: easier way to remove ID from RPCRequest without extra struct
 	var rpcRequest interface{}
@@ -259,9 +285,6 @@ func (client *RPCClient) newRequest(notification bool, method string, params ...
 			JSONRPC: "2.0",
 			Method:  method,
 			Params:  params,
-		}
-		if len(params) == 0 {
-			rpcNotification.Params = nil
 		}
 		rpcRequest = rpcNotification
 	} else {
@@ -276,9 +299,6 @@ func (client *RPCClient) newRequest(notification bool, method string, params ...
 			client.nextID++
 		}
 		client.idMutex.Unlock()
-		if len(params) == 0 {
-			request.Params = nil
-		}
 		rpcRequest = request
 	}
 

--- a/jsonrpc_test.go
+++ b/jsonrpc_test.go
@@ -90,6 +90,25 @@ func TestRpcJsonRequestStruct(t *testing.T) {
 	gomega.Expect(body).To(gomega.Equal(`{"jsonrpc":"2.0","method":"setAnonymStruct","params":[{"name":"Alex","age":33}],"id":0}`))
 }
 
+// test if the structure of an rpc request is built correctly validate the data that arrived on the server
+func TestRpcJsonRequestStructWithNamedParams(t *testing.T) {
+	gomega.RegisterTestingT(t)
+	rpcClient := NewRPCClient(httpServer.URL)
+	rpcClient.SetAutoIncrementID(false)
+
+	rpcClient.CallNamed("myMethod", map[string]interface{}{
+		"arrayOfInts":    []int{1, 2, 3},
+		"arrayOfStrings": []string{"A", "B", "C"},
+		"bool":           true,
+		"int":            1,
+		"number":         1.2,
+		"string":         "boogaloo",
+		"subObject":      map[string]interface{}{"foo": "bar"},
+		"time":           time.Unix(1136239445, 0), // Reference Unix time.
+	})
+	body := (<-requestChan).body
+	gomega.Expect(body).To(gomega.Equal(`{"jsonrpc":"2.0","method":"myMethod","params":{"arrayOfInts":[1,2,3],"arrayOfStrings":["A","B","C"],"bool":true,"int":1,"number":1.2,"string":"boogaloo","subObject":{"foo":"bar"},"time":"2006-01-02T22:04:05Z"},"id":0}`))
+}
 func TestRpcJsonResponseStruct(t *testing.T) {
 	gomega.RegisterTestingT(t)
 	rpcClient := NewRPCClient(httpServer.URL)


### PR DESCRIPTION
I've hastily added a method to allow method params to be sent by name, as described [here](http://www.jsonrpc.org/specification#parameter_structures).

I'd appreciate any feedback you could offer.

Thanks,
Ross