### PR TITLE
implemented Error interface on RPCError

### DIFF
--- a/jsonrpc.go
+++ b/jsonrpc.go
@@ -58,6 +58,10 @@ type RPCError struct {
 	Data    interface{} `json:"data"`
 }
 
+func (e *RPCError) Error() string {
+	return e.Message
+}
+
 // RPCClient sends jsonrpc requests over http to the provided rpc backend.
 // RPCClient is created using the factory function NewRPCClient().
 type RPCClient struct {

--- a/jsonrpc.go
+++ b/jsonrpc.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
 	"sync"
 )
 
@@ -59,7 +60,7 @@ type RPCError struct {
 }
 
 func (e *RPCError) Error() string {
-	return e.Message
+	return strconv.Itoa(e.Code) + ": " + e.Message
 }
 
 // RPCClient sends jsonrpc requests over http to the provided rpc backend.


### PR DESCRIPTION
Seems to make sense for RPCError to implement error.  For me it's QoL to be able to bubble it up directly, rather than creating a new error from the message.