### PR TITLE
fix go module name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module jsonrpc
+module github.com/ybbus/jsonrpc
 
 go 1.12
 


### PR DESCRIPTION
Hi!
This is small fix that makes it possible to use this repository as a go module and don't replace old imports from "github.com/ybbus/jsonrpc" to "jsonrpc"