### PR TITLE
Change module path to github.com/ybbus/jsonrpc/v3

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ybbus/jsonrpc
+module github.com/ybbus/jsonrpc/v3
 
 go 1.12
 


### PR DESCRIPTION
When using a version greater than v1, the module path should include that version.

Otherwise, when importing this module with `go get`, you'd see a require statement like this:
`github.com/ybbus/jsonrpc v2.1.2+incompatible`
(hint: `+incompatible` shows up because ybbus/jsonrpc does not respect this rule)

It should optimally be `github.com/ybbus/jsonrpc/v2 v2.1.2` instead.

The best way to fix this according to the official docs would be to release version v3.0.0 and append `/v3` to the path.

More info here:  https://github.com/golang/go/wiki/Modules#releasing-modules-v2-or-higher
>  For example, if you are the author of foo, and the latest tag for the foo repository is v2.2.2, and foo has not yet adopted modules, then the best practice would be to use v3.0.0 for the first release of foo to adopt modules (and hence the first release of foo to contain a go.mod file). Incrementing the major version in this case provides greater clarity to consumers of foo, allows for additional non-module patches or minor releases on the v2 series of foo if needed, and provides a strong signal for a module-based consumer of foo that different major versions result if you do import "foo" and a corresponding require foo v2.2.2+incompatible, vs. import "foo/v3" and a corresponding require foo/v3 v3.0.0. (Note that this advice regarding incrementing the major version when first adopting modules does not apply to pre-existing repos or packages whose latest versions are v0.x.x or v1.x.x).