### PR TITLE
strip password when logging URL

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -1,0 +1,20 @@
+package jsonrpc
+
+import (
+	"net/url"
+	"strings"
+)
+
+func stripPassword(uri string) string {
+	u, err := url.Parse(uri)
+	if err != nil {
+		return uri
+	}
+
+	_, passSet := u.User.Password()
+	if passSet {
+		return strings.Replace(u.String(), u.User.String()+"@", u.User.Username()+":***@", 1)
+	}
+
+	return u.String()
+}

--- a/utils_test.go
+++ b/utils_test.go
@@ -8,6 +8,6 @@ import (
 
 func TestPasswordStripped(t *testing.T) {
 	url := "https://user:password@my.api.com/endpoint"
-	stipped := stripPassword(url)
-	assert.Equal(t, "https://user:***@my.api.com/endpoint", stipped)
+	stripped := stripPassword(url)
+	assert.Equal(t, "https://user:***@my.api.com/endpoint", stripped)
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,0 +1,13 @@
+package jsonrpc
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPasswordStripped(t *testing.T) {
+	url := "https://user:password@my.api.com/endpoint"
+	stipped := stripPassword(url)
+	assert.Equal(t, "https://user:***@my.api.com/endpoint", stipped)
+}


### PR DESCRIPTION
This makes sure that password doesn't appear in error logs when using basic authentication. 
(The code that I used in `stripPassword` is the same that the standard library http client uses)