### PR TITLE
correct way to override Host header

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ybbus/jsonrpc/v3
+module github.com/slav123/jsonrpc
 
 go 1.17
 

--- a/jsonrpc.go
+++ b/jsonrpc.go
@@ -411,8 +411,12 @@ func (client *rpcClient) newRequest(ctx context.Context, req interface{}) (*http
 	request.Header.Set("Accept", "application/json")
 
 	// set default headers first, so that even content type and accept can be overwritten
-	for k, v := range client.customHeaders {
-		request.Header.Set(k, v)
+	for k, v := range client.customHeaders {		
+		if k == "Host" {
+			request.Host = v
+		} else {
+			request.Header.Set(k, v)
+		}
 	}
 
 	return request, nil


### PR DESCRIPTION
A host cannot be set up by `req.Header.Add` but can be overridden by `req.Host = ""`. Small patch, but makes this parameter working. 