### PR TITLE
add host header support

### DIFF
--- a/jsonrpc.go
+++ b/jsonrpc.go
@@ -412,7 +412,12 @@ func (client *rpcClient) newRequest(ctx context.Context, req interface{}) (*http
 
 	// set default headers first, so that even content type and accept can be overwritten
 	for k, v := range client.customHeaders {
-		request.Header.Set(k, v)
+		// check if header is "Host" since this will be set on the request struct itself
+		if k == "Host" {
+			request.Host = v
+		} else {
+			request.Header.Set(k, v)
+		}
 	}
 
 	return request, nil

--- a/jsonrpc_test.go
+++ b/jsonrpc_test.go
@@ -670,6 +670,25 @@ func TestRpcClientOptions(t *testing.T) {
 		check.Equal("custom-value2", reqObject.request.Header.Get("X-Custom-Header2"))
 	})
 
+	t.Run("host header should be added to request", func(t *testing.T) {
+		rpcClient := NewClientWithOpts(httpServer.URL, &RPCClientOpts{
+			CustomHeaders: map[string]string{
+				"X-Custom-Header1": "custom-value1",
+				"Host":             "my-host.com",
+				"X-Custom-Header2": "custom-value2",
+			},
+		})
+
+		responseBody = `{"result": 1}`
+		res, err := rpcClient.Call(context.Background(), "something", 1, 2, 3)
+		reqObject := <-requestChan
+		check.Nil(err)
+		check.NotNil(res)
+		check.Equal("custom-value1", reqObject.request.Header.Get("X-Custom-Header1"))
+		check.Equal("my-host.com", reqObject.request.Host)
+		check.Equal("custom-value2", reqObject.request.Header.Get("X-Custom-Header2"))
+	})
+
 	t.Run("default rpcrequest id should be customized", func(t *testing.T) {
 		rpcClient := NewClientWithOpts(httpServer.URL, &RPCClientOpts{
 			DefaultRequestID: 123,


### PR DESCRIPTION
since host header is in request struct this did not work with customHeaders.

this PR fixes it.

(see: https://github.com/ybbus/jsonrpc/pull/47 )